### PR TITLE
Build salary tracking dashboard

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next", "next/core-web-vitals"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+/.next
+/out
+
+# misc
+.DS_Store
+*.log
+.next-env.d.ts
+.env.local
+.env*.local
+
+# typescript
+*.tsbuildinfo
+
+# editor
+.vscode
+.idea

--- a/README.md
+++ b/README.md
@@ -1,4 +1,74 @@
- very first prompt. Will delete this later.
+# Salary Navigator
 
-Create an interactive app that allows me to track my salary changes over time. I will also provide my role's min mid and max comparatio ranges for each year. I have about five years of historical data. I'd like the app to beautifully visualize progression of salary data over time. It needs to be dark mode and mobile first.
+Track your salary progression against compensation bands, surface year-over-year insights, and keep a clean ledger of updates.
 
+## Features
+
+- 📈 **Rich visualizations** – Line and area charts show salary vs. band and YoY trends in a dark, mobile-first layout.
+- 🧮 **Actionable metrics** – Automatic summaries for growth, YoY deltas, compa ratio, and more.
+- 🗂️ **Supabase-backed storage** – Persist entries for each role/year with room to append new data over time.
+- 📝 **In-app editing** – Add new salary entries directly through the interface.
+
+## Getting started
+
+### 1. Configure environment variables
+
+Create a `.env.local` file with your Supabase project credentials:
+
+```bash
+NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
+```
+
+> ℹ️ `NEXT_PUBLIC_SUPABASE_ANON_KEY` is reserved for future authenticated features, but defining it keeps the client flexible.
+
+### 2. Create the storage table
+
+Run the following SQL in Supabase (SQL Editor → New query) to create the table used by the app:
+
+```sql
+create table if not exists public.salary_history (
+  id uuid default gen_random_uuid() primary key,
+  role text not null,
+  year integer not null check (year between 1900 and 2100),
+  salary numeric not null check (salary > 0),
+  range_min numeric not null check (range_min > 0),
+  range_mid numeric not null check (range_mid > 0),
+  range_max numeric not null check (range_max > 0),
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create index if not exists salary_history_year_idx on public.salary_history (year asc);
+```
+
+Grant anonymous access (if desired) by updating policies or keep it restricted and use the service-role protected API route.
+
+### 3. Install dependencies and run locally
+
+```bash
+npm install
+npm run dev
+```
+
+Visit http://localhost:3000 to interact with the dashboard.
+
+## Project structure
+
+```
+app/
+  api/salaries/route.ts   # Supabase-backed API route for CRUD operations
+  page.tsx                # Client dashboard with charts, metrics, and data table
+  layout.tsx              # Global HTML structure and metadata
+  globals.css             # Base styles + dark theme
+components/               # Reusable UI blocks (forms, charts, metrics, etc.)
+lib/supabaseAdmin.ts      # Server-side Supabase client (service role)
+types/salary.ts           # Shared TypeScript contracts
+utils/metrics.ts          # Derived analytics helpers
+```
+
+## Next steps
+
+- Authentication/authorization for multi-user access.
+- Editing & deleting entries.
+- Support for multiple roles or currencies.

--- a/app/api/salaries/route.ts
+++ b/app/api/salaries/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { fetchSalaryHistory, insertSalary } from '@/lib/supabaseAdmin';
+
+const payloadSchema = z.object({
+  role: z.string().min(2),
+  year: z.number().int().gte(1900).lte(2100),
+  salary: z.number().positive(),
+  range_min: z.number().positive(),
+  range_mid: z.number().positive(),
+  range_max: z.number().positive()
+});
+
+export async function GET() {
+  try {
+    const data = await fetchSalaryHistory();
+    return NextResponse.json(data ?? []);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ message }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  const json = await request.json();
+  const parsed = payloadSchema.safeParse(json);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { message: parsed.error.issues.map((issue) => issue.message).join(', ') },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const data = await insertSalary(parsed.data);
+    return NextResponse.json(data, { status: 201 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ message }, { status: 500 });
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,65 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #050816;
+  color: #f1f5f9;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+html, body {
+  max-width: 100vw;
+  margin: 0;
+  padding: 0;
+  background: radial-gradient(circle at top, rgba(30, 64, 175, 0.35), transparent 60%), #050816;
+  min-height: 100%;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+body {
+  display: flex;
+  justify-content: center;
+  padding: 1.5rem 1rem 3rem;
+}
+
+main {
+  width: min(960px, 100%);
+}
+
+h1, h2, h3, h4, h5, h6 {
+  margin: 0;
+  font-weight: 600;
+}
+
+p {
+  margin: 0;
+}
+
+button {
+  cursor: pointer;
+  border: none;
+  font: inherit;
+}
+
+input, select {
+  font: inherit;
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: rgba(148, 163, 184, 0.12);
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(96, 165, 250, 0.75);
+  border-radius: 9999px;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+type RootLayoutProps = {
+  children: React.ReactNode;
+};
+
+export const metadata: Metadata = {
+  title: 'Salary Navigator',
+  description: 'Track compensation growth, compare against band targets, and understand your progression over time.'
+};
+
+export default function RootLayout({ children }: RootLayoutProps) {
+  return (
+    <html lang="en">
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { PageHeader } from '@/components/PageHeader';
+import { SalaryForm } from '@/components/SalaryForm';
+import { SalaryCharts } from '@/components/SalaryCharts';
+import { SalaryTable } from '@/components/SalaryTable';
+import { MetricGrid } from '@/components/MetricGrid';
+import { SalaryEntry } from '@/types/salary';
+
+export default function HomePage() {
+  const [entries, setEntries] = useState<SalaryEntry[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadEntries = async () => {
+      try {
+        const response = await fetch('/api/salaries');
+        if (!response.ok) {
+          throw new Error('Unable to load salary history');
+        }
+        const data: SalaryEntry[] = await response.json();
+        setEntries(data);
+      } catch (loadError) {
+        setError(loadError instanceof Error ? loadError.message : 'Unexpected error');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    void loadEntries();
+  }, []);
+
+  const handleCreate = (entry: SalaryEntry) => {
+    setEntries((current) => {
+      const next = [...current, entry];
+      return next.sort((a, b) => a.year - b.year);
+    });
+  };
+
+  return (
+    <>
+      <PageHeader />
+      <MetricGrid entries={entries} />
+      <SalaryForm onCreate={handleCreate} />
+      {isLoading && !entries.length ? (
+        <p className="loading">Loading your salary history…</p>
+      ) : error ? (
+        <p className="error">{error}</p>
+      ) : (
+        <>
+          <SalaryCharts entries={entries} />
+          <SalaryTable entries={entries} />
+        </>
+      )}
+      <style jsx>{`
+        .loading {
+          color: rgba(226, 232, 240, 0.75);
+          margin-bottom: 1.5rem;
+        }
+
+        .error {
+          color: #f87171;
+          margin-bottom: 1.5rem;
+        }
+      `}</style>
+    </>
+  );
+}

--- a/components/MetricGrid.tsx
+++ b/components/MetricGrid.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useMemo } from 'react';
+import { SalaryEntry } from '@/types/salary';
+import { buildMetricSummaries } from '@/utils/metrics';
+
+type MetricGridProps = {
+  entries: SalaryEntry[];
+};
+
+export function MetricGrid({ entries }: MetricGridProps) {
+  const metrics = useMemo(() => buildMetricSummaries(entries), [entries]);
+
+  if (!metrics.length) {
+    return null;
+  }
+
+  return (
+    <section className="metric-grid" aria-label="Key compensation metrics">
+      {metrics.map((metric) => (
+        <article key={metric.label} className="metric-card">
+          <span className="metric-label">{metric.label}</span>
+          <span className="metric-value">{metric.value}</span>
+          {metric.helper && <span className="metric-helper">{metric.helper}</span>}
+        </article>
+      ))}
+      <style jsx>{`
+        .metric-grid {
+          display: grid;
+          gap: 1rem;
+          margin-bottom: 2.5rem;
+          grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        }
+
+        .metric-card {
+          background: linear-gradient(135deg, rgba(30, 64, 175, 0.45), rgba(14, 165, 233, 0.25));
+          border: 1px solid rgba(148, 163, 184, 0.18);
+          border-radius: 18px;
+          padding: 1.2rem 1.4rem;
+          display: flex;
+          flex-direction: column;
+          gap: 0.35rem;
+          box-shadow: 0 12px 24px rgba(15, 23, 42, 0.35);
+        }
+
+        .metric-label {
+          font-size: 0.85rem;
+          text-transform: uppercase;
+          letter-spacing: 0.08em;
+          color: rgba(226, 232, 240, 0.75);
+        }
+
+        .metric-value {
+          font-size: clamp(1.3rem, 3vw, 1.8rem);
+          font-weight: 700;
+          color: #f8fafc;
+        }
+
+        .metric-helper {
+          font-size: 0.85rem;
+          color: rgba(226, 232, 240, 0.65);
+        }
+      `}</style>
+    </section>
+  );
+}

--- a/components/PageHeader.tsx
+++ b/components/PageHeader.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+export function PageHeader() {
+  return (
+    <header className="page-header">
+      <div>
+        <p className="eyebrow">Salary Navigator</p>
+        <h1>Understand your compensation arc at a glance.</h1>
+      </div>
+      <p className="description">
+        Capture each compensation update, compare it against your band, and surface the insights that power smarter salary
+        conversations.
+      </p>
+      <style jsx>{`
+        .page-header {
+          display: flex;
+          flex-direction: column;
+          gap: 1rem;
+          margin-bottom: 2.4rem;
+        }
+
+        .eyebrow {
+          font-size: 0.85rem;
+          letter-spacing: 0.4em;
+          text-transform: uppercase;
+          color: rgba(148, 163, 184, 0.75);
+        }
+
+        h1 {
+          font-size: clamp(1.75rem, 5vw, 2.6rem);
+          line-height: 1.2;
+          color: #f8fafc;
+        }
+
+        .description {
+          color: rgba(226, 232, 240, 0.75);
+          font-size: 1rem;
+          max-width: 60ch;
+        }
+      `}</style>
+    </header>
+  );
+}

--- a/components/SalaryCharts.tsx
+++ b/components/SalaryCharts.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip, Legend, LineChart, Line, CartesianGrid } from 'recharts';
+import { SalaryEntry } from '@/types/salary';
+import { calculateYearOverYear, normalizeEntriesForChart } from '@/utils/metrics';
+
+const currencyFormatter = (value: number) =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0
+  }).format(value);
+
+type SalaryChartsProps = {
+  entries: SalaryEntry[];
+};
+
+export function SalaryCharts({ entries }: SalaryChartsProps) {
+  if (!entries.length) {
+    return (
+      <section className="empty-state">
+        <h2>Visuals appear once data does</h2>
+        <p>Add your first entry to unlock insights and chart your trajectory.</p>
+        <style jsx>{`
+          .empty-state {
+            text-align: center;
+            padding: 2.5rem 1.5rem;
+            background: rgba(15, 23, 42, 0.55);
+            border-radius: 18px;
+            border: 1px dashed rgba(148, 163, 184, 0.35);
+            color: rgba(226, 232, 240, 0.75);
+            margin-bottom: 2.5rem;
+          }
+
+          h2 {
+            margin-bottom: 0.5rem;
+            color: #f8fafc;
+          }
+        `}</style>
+      </section>
+    );
+  }
+
+  const areaData = normalizeEntriesForChart(entries);
+  const yoyData = calculateYearOverYear(entries);
+
+  return (
+    <section className="chart-grid">
+      <article>
+        <header>
+          <h2>Salary vs. band</h2>
+          <p>Track how your pay aligns with the compensation band for each year.</p>
+        </header>
+        <div className="chart-wrapper">
+          <ResponsiveContainer width="100%" height={320}>
+            <AreaChart data={areaData}>
+              <defs>
+                <linearGradient id="colorSalary" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="#38bdf8" stopOpacity={0.85} />
+                  <stop offset="95%" stopColor="#0ea5e9" stopOpacity={0.1} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" stroke="rgba(148, 163, 184, 0.2)" vertical={false} />
+              <XAxis dataKey="year" stroke="rgba(226, 232, 240, 0.65)" />
+              <YAxis stroke="rgba(226, 232, 240, 0.65)" tickFormatter={currencyFormatter} width={100} />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: '#0f172a',
+                  borderRadius: 12,
+                  border: '1px solid rgba(148, 163, 184, 0.25)',
+                  color: '#f8fafc'
+                }}
+                formatter={(value: number) => currencyFormatter(value)}
+              />
+              <Legend verticalAlign="top" height={36} wrapperStyle={{ color: '#e2e8f0' }} />
+              <Area type="monotone" dataKey="salary" stroke="#38bdf8" fill="url(#colorSalary)" strokeWidth={2.8} name="Salary" />
+              <Line type="monotone" dataKey="min" stroke="#f97316" strokeWidth={2} dot={false} name="Band Min" />
+              <Line type="monotone" dataKey="mid" stroke="#22d3ee" strokeDasharray="4 6" strokeWidth={2} dot={false} name="Band Mid" />
+              <Line type="monotone" dataKey="max" stroke="#34d399" strokeWidth={2} dot={false} name="Band Max" />
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
+      </article>
+      <article>
+        <header>
+          <h2>Year-over-year change</h2>
+          <p>See the percentage change in salary compared with the previous year.</p>
+        </header>
+        <div className="chart-wrapper">
+          <ResponsiveContainer width="100%" height={280}>
+            <LineChart data={yoyData}>
+              <CartesianGrid strokeDasharray="3 3" stroke="rgba(148, 163, 184, 0.2)" vertical={false} />
+              <XAxis dataKey="year" stroke="rgba(226, 232, 240, 0.65)" />
+              <YAxis
+                stroke="rgba(226, 232, 240, 0.65)"
+                tickFormatter={(value) => `${value > 0 ? '+' : ''}${value}%`}
+                width={70}
+              />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: '#0f172a',
+                  borderRadius: 12,
+                  border: '1px solid rgba(148, 163, 184, 0.25)',
+                  color: '#f8fafc'
+                }}
+                formatter={(value: number) => `${value > 0 ? '+' : ''}${value.toFixed(1)}%`}
+              />
+              <Legend verticalAlign="top" height={36} wrapperStyle={{ color: '#e2e8f0' }} />
+              <Line type="monotone" dataKey="change" stroke="#c084fc" strokeWidth={3} dot={{ r: 4 }} name="YoY %" />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </article>
+      <style jsx>{`
+        .chart-grid {
+          display: grid;
+          gap: 1.75rem;
+          margin-bottom: 2.5rem;
+        }
+
+        article {
+          background: rgba(15, 23, 42, 0.65);
+          border-radius: 20px;
+          border: 1px solid rgba(59, 130, 246, 0.25);
+          padding: 1.6rem 1.4rem 1.4rem;
+          box-shadow: 0 18px 32px rgba(2, 6, 23, 0.4);
+        }
+
+        header h2 {
+          font-size: 1.15rem;
+          margin-bottom: 0.45rem;
+        }
+
+        header p {
+          color: rgba(226, 232, 240, 0.65);
+          font-size: 0.9rem;
+          margin-bottom: 1.4rem;
+        }
+
+        .chart-wrapper {
+          width: 100%;
+          height: 100%;
+        }
+      `}</style>
+    </section>
+  );
+}

--- a/components/SalaryForm.tsx
+++ b/components/SalaryForm.tsx
@@ -1,0 +1,246 @@
+'use client';
+
+import { useState } from 'react';
+import { SalaryEntry, SalaryPayload } from '@/types/salary';
+import { z } from 'zod';
+
+type SalaryFormProps = {
+  onCreate: (entry: SalaryEntry) => void;
+};
+
+const salarySchema = z.object({
+  role: z.string().min(2, 'Role is required'),
+  year: z
+    .string()
+    .transform((value) => Number.parseInt(value, 10))
+    .pipe(z.number().min(1900).max(2100)),
+  salary: z
+    .string()
+    .transform((value) => Number.parseFloat(value))
+    .pipe(z.number().positive('Salary must be positive')),
+  range_min: z
+    .string()
+    .transform((value) => Number.parseFloat(value))
+    .pipe(z.number().positive('Min must be positive')),
+  range_mid: z
+    .string()
+    .transform((value) => Number.parseFloat(value))
+    .pipe(z.number().positive('Mid must be positive')),
+  range_max: z
+    .string()
+    .transform((value) => Number.parseFloat(value))
+    .pipe(z.number().positive('Max must be positive'))
+});
+
+export function SalaryForm({ onCreate }: SalaryFormProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [values, setValues] = useState({
+    role: '',
+    year: new Date().getFullYear().toString(),
+    salary: '',
+    range_min: '',
+    range_mid: '',
+    range_max: ''
+  });
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target;
+    setValues((current) => ({ ...current, [name]: value }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setError(null);
+
+    const result = salarySchema.safeParse(values);
+
+    if (!result.success) {
+      setError(result.error.issues[0]?.message ?? 'Invalid data');
+      setIsSubmitting(false);
+      return;
+    }
+
+    const payload: SalaryPayload = result.data;
+
+    try {
+      const response = await fetch('/api/salaries', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to save entry.');
+      }
+
+      const entry: SalaryEntry = await response.json();
+      onCreate(entry);
+      setValues((current) => ({
+        ...current,
+        salary: '',
+        range_min: '',
+        range_mid: '',
+        range_max: ''
+      }));
+    } catch (submitError) {
+      setError(submitError instanceof Error ? submitError.message : 'Unexpected error');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <section className="form-wrapper" aria-labelledby="entry-form">
+      <header>
+        <h2 id="entry-form">Add compensation data</h2>
+        <p>Keep your history up to date and watch the story evolve instantly.</p>
+      </header>
+      <form onSubmit={handleSubmit} className="form-grid">
+        <label>
+          <span>Role</span>
+          <input
+            name="role"
+            value={values.role}
+            onChange={handleChange}
+            placeholder="Senior Product Manager"
+            required
+          />
+        </label>
+        <label>
+          <span>Year</span>
+          <input name="year" value={values.year} onChange={handleChange} type="number" min="1900" max="2100" required />
+        </label>
+        <label>
+          <span>Base Salary</span>
+          <input
+            name="salary"
+            value={values.salary}
+            onChange={handleChange}
+            inputMode="decimal"
+            placeholder="160000"
+            required
+          />
+        </label>
+        <label>
+          <span>Range Min</span>
+          <input
+            name="range_min"
+            value={values.range_min}
+            onChange={handleChange}
+            inputMode="decimal"
+            placeholder="140000"
+            required
+          />
+        </label>
+        <label>
+          <span>Range Mid</span>
+          <input
+            name="range_mid"
+            value={values.range_mid}
+            onChange={handleChange}
+            inputMode="decimal"
+            placeholder="160000"
+            required
+          />
+        </label>
+        <label>
+          <span>Range Max</span>
+          <input
+            name="range_max"
+            value={values.range_max}
+            onChange={handleChange}
+            inputMode="decimal"
+            placeholder="180000"
+            required
+          />
+        </label>
+        <button type="submit" disabled={isSubmitting} className="submit-button">
+          {isSubmitting ? 'Saving…' : 'Save entry'}
+        </button>
+      </form>
+      {error && <p className="error">{error}</p>}
+      <style jsx>{`
+        .form-wrapper {
+          background: rgba(15, 23, 42, 0.65);
+          border: 1px solid rgba(59, 130, 246, 0.25);
+          border-radius: 20px;
+          padding: 1.8rem 1.5rem;
+          display: flex;
+          flex-direction: column;
+          gap: 1.5rem;
+          margin-bottom: 2.5rem;
+        }
+
+        header h2 {
+          font-size: 1.25rem;
+          margin-bottom: 0.35rem;
+        }
+
+        header p {
+          color: rgba(226, 232, 240, 0.65);
+          font-size: 0.95rem;
+        }
+
+        .form-grid {
+          display: grid;
+          gap: 1rem;
+          grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        }
+
+        label {
+          display: flex;
+          flex-direction: column;
+          gap: 0.5rem;
+          font-size: 0.9rem;
+        }
+
+        label span {
+          color: rgba(226, 232, 240, 0.75);
+        }
+
+        input {
+          border-radius: 12px;
+          border: 1px solid rgba(148, 163, 184, 0.25);
+          background: rgba(15, 23, 42, 0.55);
+          color: #f1f5f9;
+          padding: 0.6rem 0.75rem;
+          transition: border-color 0.2s ease;
+        }
+
+        input:focus {
+          outline: none;
+          border-color: rgba(96, 165, 250, 0.85);
+          box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.25);
+        }
+
+        .submit-button {
+          grid-column: 1 / -1;
+          justify-self: flex-start;
+          background: linear-gradient(135deg, rgba(37, 99, 235, 0.9), rgba(14, 165, 233, 0.9));
+          color: #f8fafc;
+          padding: 0.75rem 1.4rem;
+          border-radius: 999px;
+          font-weight: 600;
+          transition: transform 0.15s ease, box-shadow 0.15s ease;
+        }
+
+        .submit-button:disabled {
+          opacity: 0.6;
+          cursor: wait;
+        }
+
+        .submit-button:not(:disabled):hover {
+          transform: translateY(-1px);
+          box-shadow: 0 12px 24px rgba(37, 99, 235, 0.35);
+        }
+
+        .error {
+          color: #fca5a5;
+          font-size: 0.9rem;
+        }
+      `}</style>
+    </section>
+  );
+}

--- a/components/SalaryTable.tsx
+++ b/components/SalaryTable.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { SalaryEntry } from '@/types/salary';
+import { useMemo } from 'react';
+
+const currencyFormatter = (value: number) =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0
+  }).format(value);
+
+type SalaryTableProps = {
+  entries: SalaryEntry[];
+};
+
+export function SalaryTable({ entries }: SalaryTableProps) {
+  const sorted = useMemo(() => [...entries].sort((a, b) => b.year - a.year), [entries]);
+
+  if (!sorted.length) {
+    return null;
+  }
+
+  return (
+    <section className="table-card">
+      <header>
+        <h2>Data ledger</h2>
+        <p>A log of the raw inputs powering your dashboards.</p>
+      </header>
+      <div className="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>Year</th>
+              <th>Role</th>
+              <th>Salary</th>
+              <th>Band Min</th>
+              <th>Band Mid</th>
+              <th>Band Max</th>
+              <th>Compa Ratio</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((entry) => (
+              <tr key={entry.id}>
+                <td>{entry.year}</td>
+                <td>{entry.role}</td>
+                <td>{currencyFormatter(entry.salary)}</td>
+                <td>{currencyFormatter(entry.range_min)}</td>
+                <td>{currencyFormatter(entry.range_mid)}</td>
+                <td>{currencyFormatter(entry.range_max)}</td>
+                <td>{((entry.salary / entry.range_mid) * 100).toFixed(1)}%</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <style jsx>{`
+        .table-card {
+          background: rgba(15, 23, 42, 0.65);
+          border-radius: 20px;
+          border: 1px solid rgba(59, 130, 246, 0.25);
+          padding: 1.6rem 1.2rem;
+        }
+
+        header {
+          margin-bottom: 1.2rem;
+        }
+
+        header h2 {
+          font-size: 1.15rem;
+          margin-bottom: 0.4rem;
+        }
+
+        header p {
+          color: rgba(226, 232, 240, 0.65);
+          font-size: 0.9rem;
+        }
+
+        .table-wrapper {
+          overflow-x: auto;
+        }
+
+        table {
+          width: 100%;
+          border-collapse: collapse;
+          min-width: 720px;
+        }
+
+        th,
+        td {
+          text-align: left;
+          padding: 0.65rem 0.75rem;
+        }
+
+        thead th {
+          font-size: 0.8rem;
+          text-transform: uppercase;
+          letter-spacing: 0.08em;
+          color: rgba(226, 232, 240, 0.65);
+          border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+        }
+
+        tbody tr {
+          border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+        }
+
+        tbody tr:last-child {
+          border-bottom: none;
+        }
+
+        tbody td {
+          font-size: 0.95rem;
+        }
+      `}</style>
+    </section>
+  );
+}

--- a/lib/supabaseAdmin.ts
+++ b/lib/supabaseAdmin.ts
@@ -1,0 +1,50 @@
+import { SalaryPayload } from '@/types/salary';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const restEndpoint = supabaseUrl ? `${supabaseUrl.replace(/\/$/, '')}/rest/v1` : undefined;
+
+if (!supabaseUrl || !restEndpoint) {
+  throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL environment variable.');
+}
+
+if (!serviceRoleKey) {
+  throw new Error('Missing SUPABASE_SERVICE_ROLE_KEY environment variable.');
+}
+
+const defaultHeaders: Record<string, string> = {
+  apikey: serviceRoleKey,
+  Authorization: `Bearer ${serviceRoleKey}`,
+  'Content-Type': 'application/json'
+};
+
+export async function fetchSalaryHistory() {
+  const response = await fetch(`${restEndpoint}/salary_history?order=year.asc`, {
+    headers: defaultHeaders,
+    cache: 'no-store'
+  });
+
+  if (!response.ok) {
+    throw new Error(`Supabase request failed: ${await response.text()}`);
+  }
+
+  return response.json();
+}
+
+export async function insertSalary(payload: SalaryPayload) {
+  const response = await fetch(`${restEndpoint}/salary_history`, {
+    method: 'POST',
+    headers: {
+      ...defaultHeaders,
+      Prefer: 'return=representation'
+    },
+    body: JSON.stringify(payload)
+  });
+
+  if (!response.ok) {
+    throw new Error(`Supabase insert failed: ${await response.text()}`);
+  }
+
+  const data = await response.json();
+  return Array.isArray(data) ? data[0] : data;
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,11 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    serverActions: {
+      bodySizeLimit: '2mb'
+    }
+  }
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "salary-tracker",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "recharts": "^2.8.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.17",
+    "@types/react": "18.2.57",
+    "@types/react-dom": "18.2.19",
+    "eslint": "8.56.0",
+    "eslint-config-next": "14.1.0",
+    "typescript": "5.3.3"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": ["components/*"],
+      "@/lib/*": ["lib/*"],
+      "@/types/*": ["types/*"],
+      "@/utils/*": ["utils/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
+  "exclude": ["node_modules"]
+}

--- a/types/salary.ts
+++ b/types/salary.ts
@@ -1,0 +1,19 @@
+export type SalaryEntry = {
+  id: string;
+  role: string;
+  year: number;
+  salary: number;
+  range_min: number;
+  range_mid: number;
+  range_max: number;
+  created_at: string;
+};
+
+export type SalaryPayload = {
+  role: string;
+  year: number;
+  salary: number;
+  range_min: number;
+  range_mid: number;
+  range_max: number;
+};

--- a/utils/metrics.ts
+++ b/utils/metrics.ts
@@ -1,0 +1,90 @@
+import { SalaryEntry } from '@/types/salary';
+
+type MetricSummary = {
+  label: string;
+  value: string;
+  helper?: string;
+};
+
+const formatCurrency = (value: number) =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0
+  }).format(value);
+
+const formatPercent = (value: number) =>
+  `${value > 0 ? '+' : ''}${value.toFixed(1)}%`;
+
+export const buildMetricSummaries = (entries: SalaryEntry[]): MetricSummary[] => {
+  if (entries.length === 0) {
+    return [];
+  }
+
+  const sorted = [...entries].sort((a, b) => a.year - b.year);
+  const first = sorted[0];
+  const latest = sorted[sorted.length - 1];
+
+  const totalGrowth = ((latest.salary - first.salary) / first.salary) * 100;
+  const yoyChanges = sorted.slice(1).map((entry, index) => {
+    const previous = sorted[index];
+    return ((entry.salary - previous.salary) / previous.salary) * 100;
+  });
+  const latestChange = yoyChanges.length ? yoyChanges[yoyChanges.length - 1] : 0;
+
+  const averageCompaRatio =
+    sorted.reduce((sum, entry) => sum + entry.salary / entry.range_mid, 0) / sorted.length;
+
+  return [
+    {
+      label: 'Current Salary',
+      value: formatCurrency(latest.salary),
+      helper: `${latest.year} • ${latest.role}`
+    },
+    {
+      label: 'Total Growth',
+      value: formatPercent(totalGrowth),
+      helper: `${formatCurrency(first.salary)} → ${formatCurrency(latest.salary)}`
+    },
+    {
+      label: 'Last YoY Change',
+      value: formatPercent(latestChange),
+      helper: sorted.length > 1 ? `${sorted[sorted.length - 2].year} → ${latest.year}` : 'N/A'
+    },
+    {
+      label: 'Years Tracked',
+      value: `${sorted.length}`,
+      helper: `${first.year} – ${latest.year}`
+    },
+    {
+      label: 'Avg. Compa Ratio',
+      value: `${(averageCompaRatio * 100).toFixed(1)}%`,
+      helper: 'Salary ÷ band midpoint'
+    }
+  ];
+};
+
+export const calculateYearOverYear = (entries: SalaryEntry[]) => {
+  const sorted = [...entries].sort((a, b) => a.year - b.year);
+
+  return sorted.slice(1).map((entry, index) => {
+    const previous = sorted[index];
+    const change = ((entry.salary - previous.salary) / previous.salary) * 100;
+
+    return {
+      year: entry.year,
+      change
+    };
+  });
+};
+
+export const normalizeEntriesForChart = (entries: SalaryEntry[]) =>
+  [...entries]
+    .sort((a, b) => a.year - b.year)
+    .map((entry) => ({
+      year: entry.year,
+      salary: entry.salary,
+      min: entry.range_min,
+      mid: entry.range_mid,
+      max: entry.range_max
+    }));


### PR DESCRIPTION
## Summary
- scaffold a Next.js dark-mode dashboard with salary metrics, charts, and data table
- add Supabase REST API integration for persisting salary entries
- document environment variables, database schema, and local setup steps

## Testing
- not run (npm install blocked by registry access restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68db00dd2740832faa93130654a8be96