### PR TITLE
Add band guide lines and hide FAB while form open

### DIFF
--- a/components/SalaryCharts.tsx
+++ b/components/SalaryCharts.tsx
@@ -43,6 +43,9 @@ export function SalaryCharts({ entries }: SalaryChartsProps) {
 
   const areaData = normalizeEntriesForChart(entries);
   const yoyData = calculateYearOverYear(entries);
+  const hasBandData = areaData.some((point) =>
+    point.min != null && point.mid != null && point.max != null
+  );
 
   return (
     <section className="chart-grid">
@@ -74,33 +77,37 @@ export function SalaryCharts({ entries }: SalaryChartsProps) {
               />
               <Legend verticalAlign="top" height={36} wrapperStyle={{ color: '#e2e8f0' }} />
               <Area type="monotone" dataKey="salary" stroke="#38bdf8" fill="url(#colorSalary)" strokeWidth={2.8} name="Salary" />
-              <Line
-                type="monotone"
-                dataKey="min"
-                stroke="#f97316"
-                strokeWidth={2}
-                strokeDasharray="2 6"
-                dot={false}
-                name="Band Min"
-              />
-              <Line
-                type="monotone"
-                dataKey="mid"
-                stroke="#22d3ee"
-                strokeWidth={2}
-                strokeDasharray="2 6"
-                dot={false}
-                name="Band Mid"
-              />
-              <Line
-                type="monotone"
-                dataKey="max"
-                stroke="#34d399"
-                strokeWidth={2}
-                strokeDasharray="2 6"
-                dot={false}
-                name="Band Max"
-              />
+              {hasBandData && (
+                <>
+                  <Line
+                    type="monotone"
+                    dataKey="min"
+                    stroke="#f97316"
+                    strokeWidth={2}
+                    strokeDasharray="3 5"
+                    dot={false}
+                    name="Band Min"
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="mid"
+                    stroke="#22d3ee"
+                    strokeWidth={2}
+                    strokeDasharray="3 5"
+                    dot={false}
+                    name="Band Mid"
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="max"
+                    stroke="#34d399"
+                    strokeWidth={2}
+                    strokeDasharray="3 5"
+                    dot={false}
+                    name="Band Max"
+                  />
+                </>
+              )}
             </AreaChart>
           </ResponsiveContainer>
         </div>

--- a/components/SalaryForm.tsx
+++ b/components/SalaryForm.tsx
@@ -118,14 +118,17 @@ export function SalaryForm({ onCreate }: SalaryFormProps) {
 
   return (
     <>
-      <button
-        type="button"
-        className="fab"
-        onClick={() => setIsOpen(true)}
-        aria-label="Add compensation entry"
-      >
-        <span aria-hidden>+</span>
-      </button>
+      {!isOpen && (
+        <button
+          type="button"
+          className="fab"
+          onClick={() => setIsOpen(true)}
+          aria-label="Add compensation entry"
+          aria-expanded={isOpen}
+        >
+          <span aria-hidden>+</span>
+        </button>
+      )}
       {isOpen && (
         <div className="popover-backdrop" role="presentation" onClick={handleClose}>
           <section


### PR DESCRIPTION
## Summary
- render compensation band min/mid/max as dashed guide lines only when data is available
- hide the floating add button while the entry popover dialog is open to avoid duplicate triggers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db17a4ca68832f8a0353962ae0f715