### PR TITLE
Allow optional compensation band edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ create table if not exists public.salary_history (
   role text not null,
   year integer not null check (year between 1900 and 2100),
   salary numeric not null check (salary > 0),
-  range_min numeric not null check (range_min > 0),
+  range_min numeric check (range_min > 0),
   range_mid numeric not null check (range_mid > 0),
-  range_max numeric not null check (range_max > 0),
+  range_max numeric check (range_max > 0),
   created_at timestamptz not null default timezone('utc', now())
 );
 

--- a/app/api/salaries/route.ts
+++ b/app/api/salaries/route.ts
@@ -6,9 +6,9 @@ const payloadSchema = z.object({
   role: z.string().min(2),
   year: z.number().int().gte(1900).lte(2100),
   salary: z.number().positive(),
-  range_min: z.number().positive(),
+  range_min: z.number().positive().nullable(),
   range_mid: z.number().positive(),
-  range_max: z.number().positive()
+  range_max: z.number().positive().nullable()
 });
 
 export async function GET() {

--- a/components/SalaryCharts.tsx
+++ b/components/SalaryCharts.tsx
@@ -54,26 +54,33 @@ export function SalaryCharts({ entries }: SalaryChartsProps) {
 
   const areaData = normalizeEntriesForChart(entries);
   const yoyData = calculateYearOverYear(entries);
-  const hasBandData = areaData.some((point) =>
-    point.min != null && point.mid != null && point.max != null
-  );
+  const hasMinData = areaData.some((point) => point.min != null);
+  const hasMaxData = areaData.some((point) => point.max != null);
 
   const latestEntry = areaData[areaData.length - 1];
-  const currentYearMaxBand = latestEntry?.max;
+  const latestValues = latestEntry
+    ? [latestEntry.salary, latestEntry.min, latestEntry.mid, latestEntry.max].filter(
+        (value): value is number => value != null
+      )
+    : [];
   const fallbackMax = areaData.reduce((highest, point) => {
     const bandValues = [point.salary, point.min, point.mid, point.max].filter(
       (value): value is number => value != null
     );
     return bandValues.length ? Math.max(highest, ...bandValues) : highest;
   }, Number.NEGATIVE_INFINITY);
-  const fallbackMinBand = areaData.reduce(
-    (lowest, point) =>
-      point.min != null ? Math.min(lowest, point.min) : lowest,
-    Number.POSITIVE_INFINITY
-  );
+  const fallbackMinBand = areaData.reduce((lowest, point) => {
+    const bandValues = [point.salary, point.min, point.mid, point.max].filter(
+      (value): value is number => value != null
+    );
+    return bandValues.length ? Math.min(lowest, ...bandValues) : lowest;
+  }, Number.POSITIVE_INFINITY);
 
-  const computedYAxisMax =
-    currentYearMaxBand ?? (Number.isFinite(fallbackMax) ? fallbackMax : undefined);
+  const computedYAxisMax = latestValues.length
+    ? Math.max(...latestValues)
+    : Number.isFinite(fallbackMax)
+      ? fallbackMax
+      : undefined;
   const computedYAxisMin = Number.isFinite(fallbackMinBand)
     ? fallbackMinBand
     : undefined;
@@ -118,36 +125,36 @@ export function SalaryCharts({ entries }: SalaryChartsProps) {
               />
               <Legend verticalAlign="top" height={36} wrapperStyle={{ color: '#e2e8f0' }} />
               <Area type="monotone" dataKey="salary" stroke="#38bdf8" fill="url(#colorSalary)" strokeWidth={2.8} name="Salary" />
-              {hasBandData && (
-                <>
-                  <Line
-                    type="monotone"
-                    dataKey="min"
-                    stroke="#f97316"
-                    strokeWidth={2}
-                    strokeDasharray="3 5"
-                    dot={false}
-                    name="Band Min"
-                  />
-                  <Line
-                    type="monotone"
-                    dataKey="mid"
-                    stroke="#22d3ee"
-                    strokeWidth={2}
-                    strokeDasharray="3 5"
-                    dot={false}
-                    name="Band Mid"
-                  />
-                  <Line
-                    type="monotone"
-                    dataKey="max"
-                    stroke="#34d399"
-                    strokeWidth={2}
-                    strokeDasharray="3 5"
-                    dot={false}
-                    name="Band Max"
-                  />
-                </>
+              {hasMinData && (
+                <Line
+                  type="monotone"
+                  dataKey="min"
+                  stroke="#f97316"
+                  strokeWidth={2}
+                  strokeDasharray="3 5"
+                  dot={false}
+                  name="Band Min"
+                />
+              )}
+              <Line
+                type="monotone"
+                dataKey="mid"
+                stroke="#22d3ee"
+                strokeWidth={2}
+                strokeDasharray="3 5"
+                dot={false}
+                name="Band Mid"
+              />
+              {hasMaxData && (
+                <Line
+                  type="monotone"
+                  dataKey="max"
+                  stroke="#34d399"
+                  strokeWidth={2}
+                  strokeDasharray="3 5"
+                  dot={false}
+                  name="Band Max"
+                />
               )}
             </ComposedChart>
           </ResponsiveContainer>

--- a/components/SalaryForm.tsx
+++ b/components/SalaryForm.tsx
@@ -8,28 +8,52 @@ type SalaryFormProps = {
   onCreate: (entry: SalaryEntry) => void;
 };
 
+const positiveNumberField = (label: string) =>
+  z.preprocess(
+    (value) => {
+      if (typeof value !== 'string') {
+        return value;
+      }
+
+      const parsed = Number.parseFloat(value);
+      return Number.isNaN(parsed) ? undefined : parsed;
+    },
+    z
+      .number({ invalid_type_error: `${label} must be a number` })
+      .positive(`${label} must be positive`)
+  );
+
+const optionalPositiveNumberField = (label: string) =>
+  z.preprocess(
+    (value) => {
+      if (typeof value !== 'string') {
+        return value;
+      }
+
+      const trimmed = value.trim();
+      if (trimmed === '') {
+        return null;
+      }
+
+      const parsed = Number.parseFloat(trimmed);
+      return Number.isNaN(parsed) ? undefined : parsed;
+    },
+    z
+      .number({ invalid_type_error: `${label} must be a number` })
+      .positive(`${label} must be positive`)
+      .nullable()
+  );
+
 const salarySchema = z.object({
   role: z.string().min(2, 'Role is required'),
   year: z
     .string()
     .transform((value) => Number.parseInt(value, 10))
     .pipe(z.number().min(1900).max(2100)),
-  salary: z
-    .string()
-    .transform((value) => Number.parseFloat(value))
-    .pipe(z.number().positive('Salary must be positive')),
-  range_min: z
-    .string()
-    .transform((value) => Number.parseFloat(value))
-    .pipe(z.number().positive('Min must be positive')),
-  range_mid: z
-    .string()
-    .transform((value) => Number.parseFloat(value))
-    .pipe(z.number().positive('Mid must be positive')),
-  range_max: z
-    .string()
-    .transform((value) => Number.parseFloat(value))
-    .pipe(z.number().positive('Max must be positive'))
+  salary: positiveNumberField('Salary'),
+  range_min: optionalPositiveNumberField('Min'),
+  range_mid: positiveNumberField('Mid'),
+  range_max: optionalPositiveNumberField('Max')
 });
 
 export function SalaryForm({ onCreate }: SalaryFormProps) {
@@ -189,7 +213,6 @@ export function SalaryForm({ onCreate }: SalaryFormProps) {
                   onChange={handleChange}
                   inputMode="decimal"
                   placeholder="140000"
-                  required
                 />
               </label>
               <label>
@@ -211,7 +234,6 @@ export function SalaryForm({ onCreate }: SalaryFormProps) {
                   onChange={handleChange}
                   inputMode="decimal"
                   placeholder="180000"
-                  required
                 />
               </label>
               <button type="submit" disabled={isSubmitting} className="submit-button">

--- a/components/SalaryTable.tsx
+++ b/components/SalaryTable.tsx
@@ -10,6 +10,9 @@ const currencyFormatter = (value: number) =>
     maximumFractionDigits: 0
   }).format(value);
 
+const formatOptionalCurrency = (value: number | null) =>
+  value != null ? currencyFormatter(value) : '—';
+
 type SalaryTableProps = {
   entries: SalaryEntry[];
 };
@@ -46,9 +49,9 @@ export function SalaryTable({ entries }: SalaryTableProps) {
                 <td>{entry.year}</td>
                 <td>{entry.role}</td>
                 <td>{currencyFormatter(entry.salary)}</td>
-                <td>{currencyFormatter(entry.range_min)}</td>
+                <td>{formatOptionalCurrency(entry.range_min)}</td>
                 <td>{currencyFormatter(entry.range_mid)}</td>
-                <td>{currencyFormatter(entry.range_max)}</td>
+                <td>{formatOptionalCurrency(entry.range_max)}</td>
                 <td>{((entry.salary / entry.range_mid) * 100).toFixed(1)}%</td>
               </tr>
             ))}

--- a/types/salary.ts
+++ b/types/salary.ts
@@ -3,9 +3,9 @@ export type SalaryEntry = {
   role: string;
   year: number;
   salary: number;
-  range_min: number;
+  range_min: number | null;
   range_mid: number;
-  range_max: number;
+  range_max: number | null;
   created_at: string;
 };
 
@@ -13,7 +13,7 @@ export type SalaryPayload = {
   role: string;
   year: number;
   salary: number;
-  range_min: number;
+  range_min: number | null;
   range_mid: number;
-  range_max: number;
+  range_max: number | null;
 };


### PR DESCRIPTION
## Summary
- allow min and max compensation band values to be omitted across validation, API payloads, and types
- adjust charts and table rendering so optional band edges are handled gracefully in the UI
- update setup instructions to reflect nullable band edge columns

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db2695e53c832fafe5b7c1a2fafdb3