### PR TITLE
Use Supabase service role key for inserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Create a `.env.local` file with your Supabase project credentials:
 
 ```bash
 NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
 ```
 
-> ℹ️ `NEXT_PUBLIC_SUPABASE_ANON_KEY` is used for all Supabase requests.
+> ℹ️ `SUPABASE_SERVICE_ROLE_KEY` is only consumed by server code. Keep it secret and out of the client bundle.
 
 ### 2. Create the storage table
 
@@ -41,7 +41,7 @@ create table if not exists public.salary_history (
 create index if not exists salary_history_year_idx on public.salary_history (year asc);
 ```
 
-Grant anonymous access (if desired) by updating policies to allow the anon key to read and insert salary history records.
+Grant anonymous access (if desired) by updating policies to allow the anon key to read salary history records. Inserts are performed via the service role key on the API route and do not require extra policies.
 
 ### 3. Install dependencies and run locally
 
@@ -61,7 +61,7 @@ app/
   layout.tsx              # Global HTML structure and metadata
   globals.css             # Base styles + dark theme
 components/               # Reusable UI blocks (forms, charts, metrics, etc.)
-lib/supabaseAdmin.ts      # Server-side Supabase client using anon key
+lib/supabaseAdmin.ts      # Server-side Supabase client using service role key
 types/salary.ts           # Shared TypeScript contracts
 utils/metrics.ts          # Derived analytics helpers
 ```

--- a/lib/supabaseAdmin.ts
+++ b/lib/supabaseAdmin.ts
@@ -1,20 +1,20 @@
 import { SalaryPayload } from '@/types/salary';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const restEndpoint = supabaseUrl ? `${supabaseUrl.replace(/\/$/, '')}/rest/v1` : undefined;
 
 if (!supabaseUrl || !restEndpoint) {
   throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL environment variable.');
 }
 
-if (!anonKey) {
-  throw new Error('Missing NEXT_PUBLIC_SUPABASE_ANON_KEY environment variable.');
+if (!serviceRoleKey) {
+  throw new Error('Missing SUPABASE_SERVICE_ROLE_KEY environment variable.');
 }
 
 const defaultHeaders: Record<string, string> = {
-  apikey: anonKey,
-  Authorization: `Bearer ${anonKey}`,
+  apikey: serviceRoleKey,
+  Authorization: `Bearer ${serviceRoleKey}`,
   'Content-Type': 'application/json'
 };
 


### PR DESCRIPTION
## Summary
- use the Supabase service role key for server-side REST calls so inserts succeed even with row level security enabled
- update the README to document the new environment variable requirement

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbe2d23a4c832f96c55d81cbb05c2e