### PR TITLE
Switch Supabase server logic back to anon key

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,8 @@ Create a `.env.local` file with your Supabase project credentials:
 
 ```bash
 NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
-SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
 ```
-
-> ℹ️ `SUPABASE_SERVICE_ROLE_KEY` is only consumed by server code. Keep it secret and out of the client bundle.
 
 ### 2. Create the storage table
 
@@ -41,7 +39,7 @@ create table if not exists public.salary_history (
 create index if not exists salary_history_year_idx on public.salary_history (year asc);
 ```
 
-Grant anonymous access (if desired) by updating policies to allow the anon key to read salary history records. Inserts are performed via the service role key on the API route and do not require extra policies.
+Grant anonymous access (if desired) by updating policies to allow the anon key to read and insert salary history records.
 
 ### 3. Install dependencies and run locally
 
@@ -61,7 +59,7 @@ app/
   layout.tsx              # Global HTML structure and metadata
   globals.css             # Base styles + dark theme
 components/               # Reusable UI blocks (forms, charts, metrics, etc.)
-lib/supabaseAdmin.ts      # Server-side Supabase client using service role key
+lib/supabaseAdmin.ts      # Server-side Supabase client using anon key
 types/salary.ts           # Shared TypeScript contracts
 utils/metrics.ts          # Derived analytics helpers
 ```

--- a/lib/supabaseAdmin.ts
+++ b/lib/supabaseAdmin.ts
@@ -1,20 +1,20 @@
 import { SalaryPayload } from '@/types/salary';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL?.trim();
-const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY?.trim();
+const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY?.trim();
 const restEndpoint = supabaseUrl ? `${supabaseUrl.replace(/\/$/, '')}/rest/v1` : undefined;
 
 if (!supabaseUrl || !restEndpoint) {
   throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL environment variable.');
 }
 
-if (!serviceRoleKey) {
-  throw new Error('Missing SUPABASE_SERVICE_ROLE_KEY environment variable.');
+if (!anonKey) {
+  throw new Error('Missing NEXT_PUBLIC_SUPABASE_ANON_KEY environment variable.');
 }
 
 const defaultHeaders: Record<string, string> = {
-  apikey: serviceRoleKey,
-  Authorization: `Bearer ${serviceRoleKey}`,
+  apikey: anonKey,
+  Authorization: `Bearer ${anonKey}`,
   'Content-Type': 'application/json',
   Accept: 'application/json'
 };


### PR DESCRIPTION
## Summary
- revert the Supabase server helper to read the anonymous key again
- update the README instructions to point operators at the anon key configuration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbf4077508832f89a26255e29eca7b